### PR TITLE
GetViewFor in CompositionRoot

### DIFF
--- a/src/ReactiveElmish.Avalonia/CompositionRoot.fs
+++ b/src/ReactiveElmish.Avalonia/CompositionRoot.fs
@@ -76,4 +76,22 @@ type CompositionRoot() as this =
         | None ->
             failwithf $"No view registered for VM type {vmType.FullName}"
 
-    
+    ///Check to see if a view has been registered for the given view model
+    member this.HasViewFor(vm: 'ViewModel & #ReactiveElmishViewModel) =
+        let vmType = vm.GetType()
+        viewRegistry.Value |> Map.tryFind(VM.Key vmType) |> Option.isSome
+
+    ///Gets or creates a view for a given view model instance and binds it
+    member this.GetViewFor(vm: 'ViewModel & #ReactiveElmishViewModel) =
+        let vmType = vm.GetType()
+        match viewRegistry.Value |> Map.tryFind (VM.Key vmType) with
+        | Some registration -> 
+            match registration with
+            | SingletonView view ->
+                if view.DataContext = null then
+                    ViewBinder.bind (vm, view) |> snd
+                else
+                    view
+            | TransientView createView -> ViewBinder.bindWithDisposeOnViewUnload (vm, createView()) |> snd
+        | None ->
+            failwithf $"No view registered for VM type {vmType.FullName}"

--- a/src/Samples/AvaloniaExample/App.axaml.fs
+++ b/src/Samples/AvaloniaExample/App.axaml.fs
@@ -17,7 +17,7 @@ type App() =
     override this.OnFrameworkInitializationCompleted() =
         match this.ApplicationLifetime with
         | :? IClassicDesktopStyleApplicationLifetime as desktop ->         
-            let appRoot = AppCompositionRoot()
+            let appRoot = Root.Current
             desktop.MainWindow <- appRoot.GetView<ViewModels.MainViewModel>() :?> Window
         | _ -> 
             // leave this here for design view re-renders

--- a/src/Samples/AvaloniaExample/AppCompositionRoot.fs
+++ b/src/Samples/AvaloniaExample/AppCompositionRoot.fs
@@ -24,3 +24,7 @@ type AppCompositionRoot() =
             VM.Key<FilePickerViewModel>(), View.Singleton<FilePickerView>()
         ]
         
+module Root =
+    let private current = lazy AppCompositionRoot()
+    let public Current = current.Value         
+        

--- a/src/Samples/AvaloniaExample/ViewLocator.fs
+++ b/src/Samples/AvaloniaExample/ViewLocator.fs
@@ -3,30 +3,38 @@ namespace AvaloniaExample
 open System
 open Avalonia.Controls
 open Avalonia.Controls.Templates
+open Avalonia
+open ReactiveElmish
 open ReactiveElmish.Avalonia
 
 type ViewLocator() =
     interface IDataTemplate with
         
         member this.Build(data) =
-            let t = data.GetType()
-            let viewName = t.FullName.Replace("ViewModels", "Views").Replace("ViewModel", "View")
-            let parts = viewName.Split([|'['; '+'|], StringSplitOptions.RemoveEmptyEntries)
-            let name = 
-                if parts.Length > 2 
-                then parts[1]
-                else parts[0]
-            let viewType = Type.GetType(name)
-            if isNull viewType then
-                TextBlock(Text = sprintf "Not Found: %s" name)
-            else
-                let view = downcast Activator.CreateInstance(viewType)
-                match data with 
-                | :? ReactiveUI.ReactiveObject as vm ->
-                    ViewBinder.bindWithDisposeOnViewUnload (vm, view) |> snd
-                | _ ->
-                    TextBlock(Text = sprintf $"Not found: %s{name}")
+            match data with
+            | :? ReactiveElmishViewModel as reactiveViewModel -> Root.Current.GetViewFor(reactiveViewModel)
+            | _ ->
+                let t = data.GetType()
+                let viewName = t.FullName.Replace("ViewModels", "Views").Replace("ViewModel", "View")
+                let parts = viewName.Split([|'['; '+'|], StringSplitOptions.RemoveEmptyEntries)
+                let name = 
+                    if parts.Length > 2 
+                    then parts[1]
+                    else parts[0]
+                let viewType = Type.GetType(name)
+                if isNull viewType then
+                    TextBlock(Text = sprintf "Not Found: %s" name)
+                else
+                    let view = downcast Activator.CreateInstance(viewType)
+                    match data with 
+                    | :? ReactiveUI.ReactiveObject as vm ->
+                        ViewBinder.bindWithDisposeOnViewUnload (vm, view) |> snd
+                    | _ ->
+                        TextBlock(Text = sprintf $"Not found: %s{name}")
                 
         member this.Match(data) = 
-            // Only apply this IDataTemplate when data is an IElmishViewModel
-            data :? ReactiveUI.ReactiveObject
+            match data with
+            | :? ReactiveElmishViewModel as reactiveViewModel -> Root.Current.HasViewFor(reactiveViewModel)
+            | :? ReactiveUI.ReactiveObject -> true
+            | _ -> false
+


### PR DESCRIPTION
This pull request adds 2 methods in CompositionRoot:
HasViewFor(vm)
GetViewFor(vm)

This allows us to retrieve a view for an instance of a view model as opposed to using the existing GetView which creates both the view model and the view.  I believe there is a place for both.

For example having GetViewFor with a static variable for the AppCompositionRoot, we can modify the ViewLocator to use the composition root to get us a registered view for the given viewmodel rather than use reflection.