### PR TITLE
Upgrade the project to latest Avalonia 11.2.5, ReactiveUI and F# 

### DIFF
--- a/src/ReactiveElmish.Avalonia/ReactiveElmish.Avalonia.fsproj
+++ b/src/ReactiveElmish.Avalonia/ReactiveElmish.Avalonia.fsproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net9.0;net48</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -41,15 +41,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.5" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Avalonia" Version="11.2.5" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
 		<PackageReference Include="Elmish" Version="[4.0.1, 4.99]" />
-		<PackageReference Include="ReactiveUI" Version="19.5.1" />
+		<PackageReference Include="ReactiveUI" Version="20.2.45" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="6.0.7" />
+		<PackageReference Update="FSharp.Core" Version="9.0.201" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveElmish/ReactiveElmish.fsproj
+++ b/src/ReactiveElmish/ReactiveElmish.fsproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net48</TargetFrameworks>
+		<TargetFrameworks>net9.0;net48</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -31,13 +31,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DynamicData" Version="8.3.27" />
+		<PackageReference Include="DynamicData" Version="9.2.1" />
 		<PackageReference Include="Elmish" Version="[4.0.1, 4.99]" />
-		<PackageReference Include="ReactiveUI" Version="19.5.1" />
+		<PackageReference Include="ReactiveUI" Version="20.2.45" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="6.0.7" />
+		<PackageReference Update="FSharp.Core" Version="9.0.201" />
 	</ItemGroup>
 
 </Project>

--- a/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
+++ b/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     </PropertyGroup>
 
@@ -39,16 +39,14 @@
 
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.0.1" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
-        <PackageReference Include="LiveChartsCore" Version="2.0.0-beta.802" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-beta.802" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.802-11.0.0-rc1.1" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="8.3.0" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="8.3.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.5" />
+        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.2.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
+        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.1" />
+        <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.1" />
         <ProjectReference Include="..\..\ReactiveElmish.Avalonia\ReactiveElmish.Avalonia.fsproj" />
         <ProjectReference Include="..\..\ReactiveElmish\ReactiveElmish.fsproj" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/src/Samples/AvaloniaExample/Views/ChartView.axaml
+++ b/src/Samples/AvaloniaExample/Views/ChartView.axaml
@@ -31,8 +31,8 @@
                 MinWidth="600"
                 MaxWidth="2400"
                 Series="{Binding Series}" 
-                XAxes="{Binding XAxes}"
-                EasingFunction="{Binding Source={x:Null}}">
+                XAxes="{Binding XAxes}">
+                <!--EasingFunction="{Binding Source={x:Null}}">-->
             </lvc:CartesianChart>
         </Grid>
         <DataGrid ItemsSource="{Binding Actions}" AutoGenerateColumns="True" Height="200">

--- a/src/Samples/AvaloniaExample/Views/TodoListView.axaml
+++ b/src/Samples/AvaloniaExample/Views/TodoListView.axaml
@@ -40,7 +40,7 @@
 		<DataGrid DockPanel.Dock="Top" ItemsSource="{Binding Todos}" AutoGenerateColumns="False" Height="400" HorizontalAlignment="Center" SelectedIndex="-1">
 			<DataGrid.Columns>
 				<!-- Remove Button -->
-				<DataGridTemplateColumn Header="Remove">
+				<DataGridTemplateColumn Header="Remove" x:DataType="vm:TodoListViewModel">
 					<DataTemplate>
 						<Button i:Attached.Icon="fa-trash-can" FontSize="18" Command="{Binding RemoveTodo}" />
 					</DataTemplate>

--- a/src/WpfExample/WpfExample.csproj
+++ b/src/WpfExample/WpfExample.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.0",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
Upgrade the project to latest .Net 9 framework, Avalonia 11.2.5, F# 9.0, Reactive UI library version upgrade along with all other libraries.
Fixed some version upgrade related fixes in Avalonia sample application.

[Open] One open item is to remove warning related to 'sort' function (it is deprecated) with SortAndBind. 