### PR TITLE
fix AvaloniaExample AppCompositionRoot singleton instantiation

### DIFF
--- a/src/Samples/AvaloniaExample/AppCompositionRoot.fs
+++ b/src/Samples/AvaloniaExample/AppCompositionRoot.fs
@@ -5,7 +5,7 @@ open AvaloniaExample.ViewModels
 open AvaloniaExample.Views
 open ReactiveElmish.Avalonia
 
-type AppCompositionRoot() =
+type AppCompositionRoot private () =
     inherit CompositionRoot()
 
     let mainView = MainView()
@@ -24,7 +24,6 @@ type AppCompositionRoot() =
             VM.Key<FilePickerViewModel>(), View.Singleton<FilePickerView>()
         ]
 
-    static member private instanceLazy = lazy AppCompositionRoot()
-    static member Instance = AppCompositionRoot.instanceLazy.Value
+    static member val Instance = AppCompositionRoot()
         
         


### PR DESCRIPTION
In the sample code for Avalonia, if `AppCompositionRoot.Instance` is called more than once, it creates more than one instance of AppCompositionRoot. This PR fixes that. There's probably multiple ways this could be done and I'm always open for feedback.

I've prepared some branches with compelling examples:
- my fork's branch `broken-singleton-demo` with one additional commit: https://github.com/MadelineRitchie/ReactiveElmish.Avalonia/commit/88eb32165a06c074ca5e7a714b53cf06e9bd1a30 If you run from this branch, you'll notice two different Guids get printed to console. This shows that accessing `AppCompositionRoot.Instance` more than once returns different instances.
- my fork's branch `fixed-singleton-demo` with the fix commit in this PR plus the same commit from above. If you run from this branch, you'll notice the same Guid printed to console twice. This shows that accessing `AppCompositionRoot.Instance` more than once results in the same instance.