### PR TITLE
Changed BindKeyedList to dispose immediately when children are removed

### DIFF
--- a/src/ReactiveElmish/ReactiveElmishViewModel.fs
+++ b/src/ReactiveElmish/ReactiveElmishViewModel.fs
@@ -238,7 +238,7 @@ type ReactiveElmishViewModel(onPropertyChanged: string -> unit) =
                             observableCollection.RemoveAt(idx)
                             match removedItem :> obj with
                             | :? IDisposable as disposable -> 
-                                this.AddDisposable(disposable)
+                                disposable.Dispose()
                             | _ -> ()
                             
 


### PR DESCRIPTION
Changed BindKeyedList to dispose immediately when children are removed instead of when parent is disposed.

Our usecase of BindKeyedList was to create child view models in Avalonia based on an array in the parent state.  The issue we ran into was that the children could continue to try to update from the state even when removed due to the disposal being deferred.

I've tested that this change resolves the issue in our use case.  I am not sure what the advantage is of deferring the disposal of removed items.

I can provide a code sample if needed.

I've created an issue for this as well:
https://github.com/JordanMarr/ReactiveElmish.Avalonia/issues/66