### PR TITLE
Migrate from deprecated Avalonia.ReactiveUI to ReactiveUI.Avalonia.

### DIFF
--- a/src/ReactiveElmish.Avalonia/ReactiveElmish.Avalonia.fsproj
+++ b/src/ReactiveElmish.Avalonia/ReactiveElmish.Avalonia.fsproj
@@ -41,11 +41,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.5" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Avalonia" Version="11.3.9" />
+		<PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 		<PackageReference Include="Elmish" Version="[4.0.1, 4.99]" />
-		<PackageReference Include="ReactiveUI" Version="19.5.1" />
+		<PackageReference Include="ReactiveUI" Version="22.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveElmish.Wpf/ReactiveElmish.Wpf.fsproj
+++ b/src/ReactiveElmish.Wpf/ReactiveElmish.Wpf.fsproj
@@ -32,9 +32,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Elmish" Version="4.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="ReactiveUI.WPF" Version="19.5.1" />
+		<PackageReference Include="Elmish" Version="4.4.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+		<PackageReference Include="ReactiveUI.WPF" Version="22.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ReactiveElmish/ReactiveElmish.fsproj
+++ b/src/ReactiveElmish/ReactiveElmish.fsproj
@@ -18,6 +18,7 @@
 		<PackageProjectUrl>https://github.com/JordanMarr/ReactiveElmish</PackageProjectUrl>
 		<PackageTags>F# C# fsharp Elmish MVU MVVM</PackageTags>
 		<Version>1.5.0</Version>
+		<Nullable>disable</Nullable>
 		<!--Turn on warnings for unused values (arguments and let bindings) -->
 		<OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
 	</PropertyGroup>
@@ -31,9 +32,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DynamicData" Version="8.3.27" />
+		<PackageReference Include="DynamicData" Version="9.4.1" />
 		<PackageReference Include="Elmish" Version="[4.0.1, 4.99]" />
-		<PackageReference Include="ReactiveUI" Version="19.5.1" />
+		<PackageReference Include="ReactiveUI" Version="22.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
+++ b/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <TargetFramework>net8.0</TargetFramework>
+        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -38,17 +39,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.0.1" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.5" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
-        <PackageReference Include="LiveChartsCore" Version="2.0.0-beta.802" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-beta.802" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.802-11.0.0-rc1.1" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="8.3.0" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="8.3.0" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.9" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.9" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.9" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
+        <PackageReference Include="LiveChartsCore" Version="2.0.0-rc6.1" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc6.1" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc6.1" />
+        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
+        <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2" />
         <ProjectReference Include="..\..\ReactiveElmish.Avalonia\ReactiveElmish.Avalonia.fsproj" />
         <ProjectReference Include="..\..\ReactiveElmish\ReactiveElmish.fsproj" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/src/Samples/AvaloniaExample/Program.fs
+++ b/src/Samples/AvaloniaExample/Program.fs
@@ -3,7 +3,7 @@
 open System
 open Avalonia
 open AvaloniaExample
-open Avalonia.ReactiveUI
+open ReactiveUI.Avalonia
 open Projektanker.Icons.Avalonia
 open Projektanker.Icons.Avalonia.MaterialDesign
 open Projektanker.Icons.Avalonia.FontAwesome

--- a/src/Samples/AvaloniaExample/ViewModels/ChartViewModel.fs
+++ b/src/Samples/AvaloniaExample/ViewModels/ChartViewModel.fs
@@ -39,11 +39,10 @@ module Chart =
     
     // create time labeling for the X axis in the Chart visual
     let XAxes : IEnumerable<ICartesianAxis> =
-        [| Axis (
-                Labeler = (fun value -> DateTime(int64 value).ToString("HH:mm:ss")),
-                LabelsRotation = 15,
-                UnitWidth = float(TimeSpan.FromSeconds(1).Ticks),
-                MinStep = float(TimeSpan.FromSeconds(1).Ticks)
+        [|
+            DateTimeAxis(
+                TimeSpan.FromSeconds(1),
+                fun value -> value.ToString("HH:mm:ss")
             )
         |]
 

--- a/src/Samples/AvaloniaExample/Views/ChartView.axaml
+++ b/src/Samples/AvaloniaExample/Views/ChartView.axaml
@@ -31,8 +31,7 @@
                 MinWidth="600"
                 MaxWidth="2400"
                 Series="{Binding Series}" 
-                XAxes="{Binding XAxes}"
-                EasingFunction="{Binding Source={x:Null}}">
+                XAxes="{Binding XAxes}">
             </lvc:CartesianChart>
         </Grid>
         <DataGrid ItemsSource="{Binding Actions}" AutoGenerateColumns="True" Height="200">

--- a/src/WpfExample/WpfExample.csproj
+++ b/src/WpfExample/WpfExample.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that the Avalonia.ReactiveUI dependency is deprecated in favour of ReactiveUI.Avalonia.

This PR changes that dependency and bumps Avalonia, ReactiveUI, DynamicData to up-to-date versions.

It tweaks the sample ChartView to work with an updated LiveCharts, and removes an unused dependency on the commercially-licensed Avalonia.Controls.TreeDataGrid

It also opts out of nullability warnings in the ReactiveElmish project related to DynamicData. I could maybe do a follow-up PR to pass the annotations along.